### PR TITLE
Fix lint

### DIFF
--- a/src/package_name/__init__.py
+++ b/src/package_name/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for `package_name`."""


### PR DESCRIPTION
After the previous PR introducing lint for docstrings was merged, the test failed with: 
```
D104 Missing docstring in public package
--> src/package_name/__init__.py:1:1
```

This PR fixes the error.