### PR TITLE
Pin pre-commit deps, bump Actions, add PR workflow and AI-setup docs

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,12 +12,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6.2.0
       with:
         python-version: "${{ inputs.python-version }}"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"

--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup
@@ -23,7 +23,7 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.5
 
       - name: List all changed files
         run: echo '${{ steps.file_changes.outputs.all_changed_files }}'

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -87,7 +87,7 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
-          --notes ""
+          --generate-notes
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -12,15 +12,15 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -28,7 +28,7 @@ jobs:
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: python-package-distributions
           path: dist/
@@ -47,13 +47,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
 
   github-release:
     name: >-
@@ -69,13 +69,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup
@@ -32,7 +32,7 @@ jobs:
           --junitxml=junit.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,17 +59,23 @@ repos:
       - id: mdformat
         args: ["--number"]
         exclude: "^AGENTS\\.md$"
+        # Pin all plugin versions. Unpinned, a new plugin release can reformat files
+        # and fail pre-commit for reasons unrelated to the change under review.
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          - mdformat-gfm-alerts
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-black
-          - mdformat-config
-          - mdformat-shfmt
-          - mdformat-mkdocs
-          - mdformat-toc
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+          - mdformat-tables==1.0.0
+          - mdformat-frontmatter==2.0.10
+          - mdformat-black==0.1.1
+          - mdformat-config==0.2.1
+          - mdformat-shfmt==0.2.0
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.5.0
+          # shfmt-py bundles the `shfmt` binary that mdformat-shfmt invokes.
+          # Pinning here (and mirroring in pyproject.toml dev deps) keeps the
+          # binary version stable across machines.
+          - shfmt-py==3.12.0.2
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,31 @@ should also refer to `CONTRIBUTORS.md`.
 - Use `gh` CLI for all GitHub operations (PRs, issues, code search, actions). Do not use the GitHub MCP
   server — `gh` is more reliable, uses far fewer tokens, and Claude already knows it well.
 
+### Pull Requests
+
+- **Link PRs to issues with closing keywords.** If the PR resolves an issue, include `Closes #<n>`
+  (or `Fixes #<n>` / `Resolves #<n>`) in the PR body so GitHub auto-closes the issue on merge.
+  For PRs that relate to an issue but do not fully resolve it, use `Refs #<n>` instead so the
+  issue stays open.
+- **Watch CI after pushing.** Every time you push a commit to a PR branch, wait for the CI checks
+  to complete, then assess the results. Use `gh pr checks <pr-number> --watch` (or
+  `gh run watch <run-id>`) to block on completion. If any check fails, pull the logs via
+  `gh run view --log-failed`, diagnose, fix, and push again. Do not declare a PR ready for review
+  while CI is red.
+- **Respond individually to every PR review comment.** For each line comment and each top-level
+  review comment, post a reply on that specific comment (via `gh api` to
+  `/repos/:owner/:repo/pulls/:pr/comments/:id/replies` for line comments, or the issue-comment
+  endpoint for top-level comments). Each reply should either (a) describe how the comment was
+  addressed (with a commit SHA if applicable), (b) answer the question posed, or (c) push back
+  with reasoning if you disagree. Do **not** consolidate responses into a single summary comment
+  on the PR — reviewers need to track resolution per thread.
+- **Sync with main via merge, not rebase.** To pick up new changes from `main` into a PR branch,
+  run `git merge origin/main` and push. Do not rebase + force-push unless there is a specific
+  reason (e.g., the branch history is obviously broken, or the maintainer asks). Merge preserves
+  review context: in-flight review comments stay anchored to the lines they were written on, and
+  reviewers can see exactly what you added since their last pass. Force-pushes invalidate that
+  context.
+
 ## CI
 
 - **Tests**: Run on push to `main` and on PRs (`uv run pytest` with coverage uploaded to Codecov).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,19 +51,40 @@ should also refer to `CONTRIBUTORS.md`.
   `gh run watch <run-id>`) to block on completion. If any check fails, pull the logs via
   `gh run view --log-failed`, diagnose, fix, and push again. Do not declare a PR ready for review
   while CI is red.
-- **Respond individually to every PR review comment.** For each line comment and each top-level
-  review comment, post a reply on that specific comment (via `gh api` to
-  `/repos/:owner/:repo/pulls/:pr/comments/:id/replies` for line comments, or the issue-comment
-  endpoint for top-level comments). Each reply should either (a) describe how the comment was
-  addressed (with a commit SHA if applicable), (b) answer the question posed, or (c) push back
-  with reasoning if you disagree. Do **not** consolidate responses into a single summary comment
-  on the PR — reviewers need to track resolution per thread.
+- **Respond individually to every PR review comment.** Scan *both* locations: in-line review
+  comments (attached to diff lines, fetched via `gh api /repos/:owner/:repo/pulls/:pr/comments`)
+  *and* top-level PR conversation comments (fetched via
+  `gh api /repos/:owner/:repo/issues/:pr/comments`). It is easy to miss one set if you only
+  look at the diff. For each comment, post a reply on that specific thread — use the
+  `/repos/:owner/:repo/pulls/:pr/comments/:id/replies` endpoint for line comments and the
+  issue-comment endpoint for top-level comments. Each reply should either (a) describe how the
+  comment was addressed (with a commit SHA if applicable), (b) answer the question posed, or
+  (c) push back with reasoning if you disagree. Do **not** consolidate responses into a single
+  summary comment on the PR — reviewers need to track resolution per thread.
+- **Resolve AI review threads when fully addressed.** For straightforward Copilot / AI-reviewer
+  line comments where the fix is unambiguous and your reply is a simple acknowledgment, mark
+  the review thread resolved via the GraphQL API:
+  `gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"<id>"}){thread{isResolved}}}'`.
+  Get thread IDs from the PR's `reviewThreads` GraphQL field. This only applies to *review
+  threads* (line comments) — top-level PR comments have no resolved state. Do **not**
+  auto-resolve threads from human reviewers; leave that for the reviewer who raised the comment.
 - **Sync with main via merge, not rebase.** To pick up new changes from `main` into a PR branch,
   run `git merge origin/main` and push. Do not rebase + force-push unless there is a specific
   reason (e.g., the branch history is obviously broken, or the maintainer asks). Merge preserves
   review context: in-flight review comments stay anchored to the lines they were written on, and
   reviewers can see exactly what you added since their last pass. Force-pushes invalidate that
   context.
+- **Scan for upstream branch updates at the start of every work stream and periodically.**
+  Before starting new work, and on long-running branches, run `git fetch --all --prune` and
+  check whether the branch you are based on (typically `main`, or a parent branch for stacked
+  PRs) has moved: `git log --oneline HEAD..origin/<base>`. If so, merge the updates in
+  (`git merge origin/<base>`) before continuing. This keeps stacked PRs coherent, avoids
+  large late-stage merge conflicts, and surfaces conflicting work from other branches early.
+- **Consider squash vs. regular merge on every PR.** Default to a regular merge; use squash
+  only when the PR is a single logical change whose per-commit history adds no value. **Never
+  squash roll-up PRs or release-candidate PRs going into `main`** — squashing collapses the
+  component commits that record what actually shipped, and the individual commit history on
+  those PRs is load-bearing (for changelogs, bisecting, and attribution).
 
 ## CI
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,3 +56,81 @@ uv run pytest -v
 
 Tests and pre-commit checks are run as part of the continuous integration process, so any failures will prevent
 pull requests from being merged.
+
+## AI-Assisted Development
+
+This template is designed to work well with LLM coding agents. Agent-specific instructions live in
+`AGENTS.md` (read by Claude Code, Cursor, Copilot, Codex CLI, Aider, and others). `CLAUDE.md` is a
+symlink to `AGENTS.md` so Claude Code picks up the same instructions via its native path.
+
+The rest of this section covers one-time setup for agent-assisted work on a fresh machine. It is
+optional — you can contribute without any of this — but following it lets agents be productive on
+the repo without repeated prompting.
+
+### Claude Code
+
+[Claude Code](https://docs.claude.com/en/docs/claude-code) is Anthropic's terminal-based coding
+agent. Install and authenticate:
+
+```bash
+# Requires Node.js >= 18
+npm install -g @anthropic-ai/claude-code
+claude --version
+claude auth login
+```
+
+Start it inside the project directory (`claude`) and it will read `AGENTS.md` / `CLAUDE.md`
+automatically on session start.
+
+### GitHub CLI (`gh`)
+
+Agents should use the `gh` CLI for all GitHub operations (PRs, issues, releases, actions logs).
+It is faster, more reliable, and cheaper in tokens than the GitHub MCP server.
+
+```bash
+# Ubuntu/Debian
+sudo apt install gh
+
+# macOS
+brew install gh
+
+gh auth login
+```
+
+### Web search MCP (recommended)
+
+Claude Code has no built-in internet access. Adding a web-search MCP lets agents look up current
+docs, verify library behavior, and check recent releases.
+
+[Brave Search](https://brave.com/search/api/) (free tier, general-purpose search):
+
+```bash
+claude mcp add brave-search --scope user \
+	-e BRAVE_API_KEY=your-key \
+	-- npx -y @modelcontextprotocol/server-brave-search
+```
+
+### Library docs MCP (recommended)
+
+[Context7](https://context7.com/) fetches current, version-specific documentation for libraries,
+frameworks, and SDKs. No API key required. This is more reliable than web search for library-
+specific questions because it pulls from the actual docs.
+
+```bash
+claude mcp add context7 --scope user -- npx -y @upstash/context7-mcp
+```
+
+Install these with `--scope user` so they are available across all your projects, not just this
+one.
+
+### Other agents
+
+Most modern LLM coding agents read `AGENTS.md` natively (Cursor, Codex CLI, Aider, Windsurf,
+GitHub Copilot). For agents that expect a different filename (e.g., Gemini CLI expects
+`GEMINI.md`), symlink it:
+
+```bash
+ln -s AGENTS.md GEMINI.md
+```
+
+This keeps one source of truth for agent instructions.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,10 @@ template is a good starting point.
 This file provides structured instructions for AI coding agents (Claude Code, Cursor, Copilot,
 Codex, Gemini CLI, and others). It documents build commands, test conventions, code style rules,
 and repository boundaries so that agents can work effectively without repeated prompting. The
-`CLAUDE.md` symlink ensures Claude Code also reads this file via its native path.
+`CLAUDE.md` symlink ensures Claude Code also reads this file via its native path. See the
+"AI-Assisted Development" section of [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for one-time setup
+instructions covering Claude Code, the `gh` CLI, and recommended MCP servers for web search and
+library documentation.
 
 ### Repository management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,12 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "pre-commit<4", "ruff", "pytest", "pytest-cov", "pretty-print-directory"
+  "pre-commit<4", "ruff", "pytest", "pytest-cov", "pretty-print-directory",
+  # shfmt-py bundles the `shfmt` binary used by the mdformat-shfmt pre-commit
+  # hook. Pinning it here (in addition to the pre-commit hook's
+  # additional_dependencies) gives a single source of truth and keeps local
+  # `uv run mdformat ...` runs consistent with CI pre-commit runs.
+  "shfmt-py==3.12.0.2",
 ] # Add your development (lint, test) dependencies here
 docs = [] # Add your documentation dependencies here (I recommend mkdocs-material)
 

--- a/uv.lock
+++ b/uv.lock
@@ -140,6 +140,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "shfmt-py" },
 ]
 
 [package.metadata]
@@ -151,6 +152,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "shfmt-py", specifier = "==3.12.0.2" },
 ]
 docs = []
 
@@ -299,6 +301,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/14/2ad38fd4037daab9e023456a4a40ed0154e9971f8d6aed41bdea390aabd9/ruff-0.12.10-py3-none-win_amd64.whl", hash = "sha256:7837eca8787f076f67aba2ca559cefd9c5cbc3a9852fd66186f4201b87c1563e", size = 13004616, upload-time = "2025-08-21T18:23:17.422Z" },
     { url = "https://files.pythonhosted.org/packages/24/3c/21cf283d67af33a8e6ed242396863af195a8a6134ec581524fd22b9811b6/ruff-0.12.10-py3-none-win_arm64.whl", hash = "sha256:cc138cc06ed9d4bfa9d667a65af7172b47840e1a98b02ce7011c391e54635ffc", size = 12074225, upload-time = "2025-08-21T18:23:20.137Z" },
 ]
+
+[[package]]
+name = "shfmt-py"
+version = "3.12.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/d9/a1ea26749bd19467e9fbfe7b34e6c8df517e01de4028a45b954eebe8c03b/shfmt_py-3.12.0.2.tar.gz", hash = "sha256:6a0dc675b37d000eb236609cf15aedd9e7a538927ea02c57b617908b6f237e9c", size = 4467, upload-time = "2025-07-08T06:54:40.396Z" }
 
 [[package]]
 name = "virtualenv"


### PR DESCRIPTION
Stacked on #6. Merge that first, then this rebases cleanly onto main.

## Summary

### Dependency and action pinning (commit 1)

- Pin every `additional_dependency` of the `mdformat` pre-commit hook to an explicit version so a new plugin release cannot silently reformat files and fail CI for reasons unrelated to the change under review.
- Add `shfmt-py==3.12.0.2` both to the `mdformat` hook's `additional_dependencies` (so the `shfmt` binary is available inside pre-commit's isolated env) and to `pyproject.toml` dev deps (so local `uv run mdformat` runs work without a system-level install).
- Bump GitHub Actions to current pinned versions: `actions/checkout` v6.0.2, `setup-python` v6.2.0, `upload-artifact` v4.6.2, `download-artifact` v4.3.0, `astral-sh/setup-uv` v8.1.0, `pypa/gh-action-pypi-publish` v1.14.0, `sigstore/gh-action-sigstore-python` v3.3.0, `tj-actions/changed-files` v47.0.5, `codecov/codecov-action` v6.0.0, `codecov/test-results-action` v1.2.1. Kept `upload/download-artifact` on v4 since v5+ had breaking changes.

### PR workflow + AI-setup docs (commit 2)

- Extend `AGENTS.md` with a Pull Requests section covering: linking PRs to issues via closing keywords, watching CI after pushing, replying per-comment rather than with a consolidated summary, and syncing with main via merge (not rebase + force-push).
- Add an AI-Assisted Development section to `CONTRIBUTORS.md` with setup instructions for Claude Code, the `gh` CLI, a Brave Search MCP, and Context7 MCP. Referenced from the README.

Refs #7 (type-hint checker investigation, which will use the pinning machinery introduced here).

## Test plan

- [x] `uv run pre-commit run --all-files` passes (idempotently)
- [x] `uv run pytest -v` passes
- [ ] CI green on this PR (Tests + Code Quality PR)
- [ ] Bumped Action versions resolve and run successfully on GitHub-hosted runners