### PR TITLE
Add actionlint and uv-lock pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,14 @@ repos:
     hooks:
       - id: actionlint
 
+  # Keep uv.lock in sync with pyproject.toml. Without this hook it is easy to
+  # change a dependency and forget to regenerate the lockfile, breaking
+  # reproducibility for collaborators and CI.
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.13
+    hooks:
+      - id: uv-lock
+
   # md formatting
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,13 @@ repos:
     hooks:
       - id: shellcheck
 
+  # GitHub Actions workflow linter (catches expression typos, bad action inputs,
+  # invalid runner labels, shell errors in `run:` blocks via shellcheck, etc.)
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   # md formatting
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22


### PR DESCRIPTION
## Summary

Add two new pre-commit hooks that close gaps in the current validation stack:

**[actionlint](https://github.com/rhysd/actionlint) v1.7.12** — lints `.github/workflows/*.yaml` for issues `check-yaml` misses:
- Invalid `${{ ... }}` expression syntax
- Misspelled action inputs/outputs and undefined contexts (e.g., `${{ secrets.WRONG_NAME }}`)
- Invalid runner labels and matrix syntax
- Shell errors inside `run:` blocks (via shellcheck)

**[astral-sh/uv-pre-commit](https://github.com/astral-sh/uv-pre-commit) `uv-lock` hook, v0.11.13** — reruns `uv lock` whenever `pyproject.toml` changes, so `uv.lock` never drifts out of sync. Without this hook, it's easy to merge a dependency change without regenerating the lockfile, breaking reproducibility for collaborators and CI.

Both pass cleanly on the existing repo — no fixes required.

> [!NOTE]
> `nbstripout` was also raised as a candidate but is already installed in the pre-commit config (line 90).

## Test plan

- [x] `uv run pre-commit run actionlint --all-files` passes
- [x] `uv run pre-commit run uv-lock --all-files` passes
- [ ] CI green on this PR