### PR TITLE
Add gitleaks/validate-pyproject/deptry hooks and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # GitHub Actions: track action versions across workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+
+  # Python dependencies via uv (pyproject.toml + uv.lock).
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      python:
+        patterns: ["*"]
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,34 @@ repos:
     hooks:
       - id: uv-lock
 
+  # Validate pyproject.toml against PEP 517/518/621 schemas. Catches typos and
+  # structural errors (misspelled keys, wrong types, bad version specifiers)
+  # that the basic `check-toml` hook silently accepts.
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
+
+  # Secret scanner. Far broader than detect-private-key (which only catches
+  # SSH keys): ~100 rules for AWS, GCP, Stripe, Slack, generic API tokens, etc.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  # Dependency hygiene: catches unused deps in pyproject.toml, imports of
+  # packages not declared as deps, and transitive imports that should be
+  # declared as direct deps. Runs via `uv` so it has access to the project's
+  # resolved environment.
+  - repo: local
+    hooks:
+      - id: deptry
+        name: deptry
+        entry: uv run --with deptry==0.25.1 deptry src
+        language: system
+        pass_filenames: false
+        always_run: true
+
   # md formatting
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This template contains the following files:
 │   ├── actions
 │   │   └── setup
 │   │       └── action.yaml
+│   ├── dependabot.yml
 │   └── workflows
 │       ├── code-quality-main.yaml
 │       ├── code-quality-pr.yaml


### PR DESCRIPTION
## Summary

Three more pre-commit hooks plus a Dependabot config. (Reopening as a new PR — original #10 was auto-closed when its stacked base branch was deleted after #9 merged.)

### Pre-commit additions

- **[gitleaks](https://github.com/gitleaks/gitleaks) v8.30.1** — broad secret scanner (~100 rules: AWS, GCP, Stripe, Slack, generic API tokens). The existing `detect-private-key` only catches SSH keys.
- **[validate-pyproject](https://github.com/abravalheri/validate-pyproject) v0.25** — validates `pyproject.toml` against PEP 517/518/621 schemas (`check-toml` only checks TOML syntax).
- **[deptry](https://github.com/fpgmaas/deptry) 0.25.1** — dependency hygiene. Flags unused deps in `pyproject.toml`, imports of undeclared packages, transitive imports treated as direct. Wired as a `local` hook running via `uv run --with deptry==0.25.1`.

### Dependabot

`.github/dependabot.yml` with monthly cadence and per-ecosystem grouping. Covers `github-actions` and `uv` ecosystems.

### Curated out

- **pyproject-fmt** — orphans inline teaching-comments anchored to empty section headers; renames the package via PEP 503 normalization.
- **interrogate** — redundant with ruff's `D` rules already in `pyproject.toml`.
- **commitizen** — high commit-time friction; payoff duplicated by `gh release create --generate-notes`.
- **check-manifest** — obsolete for `pyproject.toml` + `setuptools.packages.find`.
- **zizmor** — surfaces 44 real findings; separate security-hardening PR.

## Test plan

- [x] All new hooks pass `pre-commit run --all-files` locally
- [x] CI was green on previous incarnation of this PR (#10)