### PR TITLE
Skip patch Action updates and Codecov on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     # and yanked before they propagate here.
     cooldown:
       default-days: 7
+    # Skip patch-level Action updates — they're almost always non-functional
+    # changes to the action's own README or CI. Security advisories fire on
+    # a separate channel regardless of this filter.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     groups:
       actions:
         patterns: ["*"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,12 @@ jobs:
           --cov-report=term
           --junitxml=junit.xml
 
+      # Skip Codecov on Dependabot PRs: workflow runs from Dependabot do not
+      # have access to repository secrets (a deliberate GitHub security
+      # policy), so CODECOV_TOKEN is empty and the upload fails. Coverage on
+      # dependency bumps is not meaningful anyway.
       - name: Upload coverage to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -45,7 +50,7 @@ jobs:
           verbose: true
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.actor != 'dependabot[bot]' }}
         uses: codecov/test-results-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,5 @@ WARP.md
 # Claude Code local/ephemeral files
 .claude/settings.local.json
 .claude/memory/
+.claude/*.lock
+.claude/scheduled_tasks/


### PR DESCRIPTION
## Summary

Three small dependabot-related quality-of-life fixes following the merge of #12.

1. **`dependabot.yml`** — ignore `version-update:semver-patch` for the `github-actions` ecosystem. Action-repo patches are almost always non-functional (README/CI changes); minor and major updates are where real changes ship. Keeps the monthly grouped PR diffs focused on signal. Security advisories fire on a separate channel and are unaffected. Left the `uv` ecosystem unfiltered — a Python patch can fix a real downstream bug.

2. **`tests.yaml`** — skip Codecov upload steps on Dependabot PRs. PR #12's CI failed in the Codecov upload because Dependabot-triggered workflow runs do not have access to repository secrets (a deliberate GitHub security policy), so `CODECOV_TOKEN` was empty and the upload returned `"Token required because branch is protected"`. Coverage on dependency bumps is not meaningful anyway. Real contributor PRs and main pushes still upload normally.

3. **`.gitignore`** — also exclude `.claude/*.lock` and `.claude/scheduled_tasks/` (ephemeral state from Claude Code's scheduling system).

## Test plan

- [x] Pre-commit clean
- [ ] CI green