### PR TITLE
Document UV, dedup AGENTS.md vs CONTRIBUTORS.md, fix doc staleness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,112 +1,43 @@
 # Agent Guidelines for McDermott Health AI Lab Projects
 
-This file provides instructions for AI coding agents working on this repository. Human contributors
-should also refer to `CONTRIBUTORS.md`.
+This file is read by AI coding agents (Claude Code, Cursor, Copilot, Codex CLI, Aider, Gemini CLI,
+and others). `CLAUDE.md` is a symlink to this file.
 
-## Build System
+## Read `CONTRIBUTORS.md` first
 
-- **Package manager**: `uv` (not pip, not conda, not poetry).
-- **Install**: `uv sync` to set up the environment. Use `uv run <cmd>` to run commands.
-- **Pre-commit**: `uv run pre-commit install` (first time), then `uv run pre-commit run --all-files`.
-- **Python version**: 3.12+ (see `.python-version`).
-- **Versioning**: Managed by `setuptools-scm` via git tags (e.g., `git tag 0.1.0`). Do not hardcode versions.
+**The project's conventions live in [`CONTRIBUTORS.md`](CONTRIBUTORS.md): build system (uv),
+testing, code style, issue/PR workflow, repository conventions.** Follow them. The notes below are
+agent-specific additions and reminders that build on those conventions — they are not a substitute.
 
-## Testing
+## Agent-specific tooling
 
-- **Run tests**: `uv run pytest -v`
-- **Framework**: `pytest` with `pytest-cov` for coverage.
-- **Doctests are first-class tests.** Prefer writing API-validating tests as doctests in docstrings and
-  markdown files. Use standalone `tests/**/test_*.py` files only for tests that would be excessively long,
-  complex, or unclear as doctests. The `conftest.py` in the project root pre-populates the doctest namespace
-  (e.g., `Path`, `datetime`, `tempfile`) so you rarely need imports in doctests.
-- **Doctest format in markdown**: Use `>>>` / `...` prompts. A blank line must separate the final output
-  line from the closing triple-backtick.
-- **Useful test helpers** (available in doctest namespace if installed): `yaml_to_disk` for creating temp
-  directory structures from YAML, `print_directory` for directory tree display.
-- **TDD**: When fixing bugs or adding features, write a failing test first, confirm the failure captures the
-  intended behavior, then implement the fix.
+- **Use `gh` CLI for all GitHub operations** (PRs, issues, code search, actions logs). Do **not**
+  use the GitHub MCP server — `gh` is faster, more reliable, and uses far fewer tokens for the
+  same operations.
+- **Doctest namespace is pre-populated.** The project root `conftest.py` registers `Path`,
+  `datetime`, `tempfile`, plus `yaml_to_disk` and `print_directory` / `PrintConfig` (if installed)
+  into the doctest namespace. You rarely need explicit imports inside doctests.
 
-## Code Style
+## Working style
 
-- **Linter/formatter**: `ruff` (configured in `pyproject.toml`). Line length 110.
-- **Style guide**: Google Python Style Guide.
-- **Docstrings**: Google style. All public functions, classes, and modules must have docstrings.
-- **Imports**: Sorted by `isort` rules via ruff. No unused imports (except `__init__.py` re-exports).
-- **Pre-commit hooks auto-fix** formatting, so run `uv run pre-commit run --all-files` before committing
-  to catch and apply fixes.
+- **TDD.** When fixing bugs or adding features, write a failing test first, confirm the failure
+  captures the intended behavior, then implement the fix.
+- **Pre-commit hooks auto-fix many issues** (formatting, import sorting, EOF newlines, markdown
+  format). Run `uv run pre-commit run --all-files` before committing — it will modify files. Stage
+  the result.
+- **Doctests are first-class.** Prefer adding API-validating tests as doctests in docstrings or
+  markdown files; standalone `tests/**/test_*.py` files are for cases where a doctest would be
+  excessively long or unclear.
 
-## GitHub
+## What not to do
 
-- Use `gh` CLI for all GitHub operations (PRs, issues, code search, actions). Do not use the GitHub MCP
-  server — `gh` is more reliable, uses far fewer tokens, and Claude already knows it well.
-
-### Pull Requests
-
-- **Link PRs to issues with closing keywords.** If the PR resolves an issue, include `Closes #<n>`
-  (or `Fixes #<n>` / `Resolves #<n>`) in the PR body so GitHub auto-closes the issue on merge.
-  For PRs that relate to an issue but do not fully resolve it, use `Refs #<n>` instead so the
-  issue stays open.
-- **Watch CI after pushing.** Every time you push a commit to a PR branch, wait for the CI checks
-  to complete, then assess the results. Use `gh pr checks <pr-number> --watch` (or
-  `gh run watch <run-id>`) to block on completion. If any check fails, pull the logs via
-  `gh run view --log-failed`, diagnose, fix, and push again. Do not declare a PR ready for review
-  while CI is red.
-- **Respond individually to every PR review comment.** Scan *both* locations: in-line review
-  comments (attached to diff lines, fetched via `gh api /repos/:owner/:repo/pulls/:pr/comments`)
-  *and* top-level PR conversation comments (fetched via
-  `gh api /repos/:owner/:repo/issues/:pr/comments`). It is easy to miss one set if you only
-  look at the diff. For each comment, post a reply on that specific thread — use the
-  `/repos/:owner/:repo/pulls/:pr/comments/:id/replies` endpoint for line comments and the
-  issue-comment endpoint for top-level comments. Each reply should either (a) describe how the
-  comment was addressed (with a commit SHA if applicable), (b) answer the question posed, or
-  (c) push back with reasoning if you disagree. Do **not** consolidate responses into a single
-  summary comment on the PR — reviewers need to track resolution per thread.
-- **Resolve AI review threads when fully addressed.** For straightforward Copilot / AI-reviewer
-  line comments where the fix is unambiguous and your reply is a simple acknowledgment, mark
-  the review thread resolved via the GraphQL API:
-  `gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"<id>"}){thread{isResolved}}}'`.
-  Get thread IDs from the PR's `reviewThreads` GraphQL field. This only applies to *review
-  threads* (line comments) — top-level PR comments have no resolved state. Do **not**
-  auto-resolve threads from human reviewers; leave that for the reviewer who raised the comment.
-- **Sync with main via merge, not rebase.** To pick up new changes from `main` into a PR branch,
-  run `git merge origin/main` and push. Do not rebase + force-push unless there is a specific
-  reason (e.g., the branch history is obviously broken, or the maintainer asks). Merge preserves
-  review context: in-flight review comments stay anchored to the lines they were written on, and
-  reviewers can see exactly what you added since their last pass. Force-pushes invalidate that
-  context.
-- **Scan for upstream branch updates at the start of every work stream and periodically.**
-  Before starting new work, and on long-running branches, run `git fetch --all --prune` and
-  check whether the branch you are based on (typically `main`, or a parent branch for stacked
-  PRs) has moved: `git log --oneline HEAD..origin/<base>`. If so, merge the updates in
-  (`git merge origin/<base>`) before continuing. This keeps stacked PRs coherent, avoids
-  large late-stage merge conflicts, and surfaces conflicting work from other branches early.
-- **Consider squash vs. regular merge on every PR.** Default to a regular merge; use squash
-  only when the PR is a single logical change whose per-commit history adds no value. **Never
-  squash roll-up PRs or release-candidate PRs going into `main`** — squashing collapses the
-  component commits that record what actually shipped, and the individual commit history on
-  those PRs is load-bearing (for changelogs, bisecting, and attribution).
-
-## CI
-
-- **Tests**: Run on push to `main` and on PRs (`uv run pytest` with coverage uploaded to Codecov).
-- **Code quality**: Pre-commit hooks run on changed files (PRs) or all files (main pushes).
-- **Build**: `uv build` on every push; PyPI publish on git tags via trusted publishing.
-- All CI checks must pass before merging a PR.
-
-## Repository Conventions
-
-- **No data in the repo.** Datasets (public or private) belong outside the repository. Never commit data
-  files, even to private repos.
-- **No secrets in the repo.** API keys, tokens, and credentials must not appear in commits. If accidentally
-  committed, purge from git history immediately.
-- **Commit messages**: Clear and focused. One logical change per commit.
-- **Branching**: Use feature branches and pull requests for all changes to `main`.
-- **Semantic versioning**: Managed through git tags.
-- **Notebooks**: Cell outputs are stripped on commit via `nbstripout`. Notebooks are linted via `nbQA`.
-
-## What Not to Do
-
-- Do not use `pip install` directly; use `uv sync` or `uv add`.
-- Do not skip or disable pre-commit hooks.
-- Do not add broad `# noqa` or `# type: ignore` comments without a specific code and justification.
-- Do not modify CI workflows without discussing with maintainers first.
+- Do not use `pip install` directly — use `uv sync` or `uv add` (see CONTRIBUTORS.md "Build
+  System: uv").
+- Do not skip or disable pre-commit hooks (no `--no-verify`).
+- Do not add broad `# noqa` or `# type: ignore` comments without a specific rule code and a
+  one-line justification.
+- Do not modify CI workflows (`.github/workflows/*.yaml`) without discussing with maintainers
+  first. Workflow security is enforced by `zizmor` (see `.github/zizmor.yml`); changes there often
+  surface real security findings.
+- Do not commit data files or secrets. `gitleaks` runs as a pre-commit hook but treat it as a
+  backstop, not a substitute for care.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,9 @@
 # Contributors Guide
 
-Thank you for your interest in contributing to this project. The following sections outline the expectations
-for contributors.
+Thank you for your interest in contributing to this project. This document is the **source of truth**
+for build, test, code-style, and workflow conventions used across McDermott Health AI Lab
+repositories. AI coding agents (Claude Code, Cursor, Copilot, Codex CLI, Aider, and others) are
+also instructed via `AGENTS.md` to follow the guidelines here.
 
 ## Good Practice
 
@@ -10,58 +12,206 @@ for contributors.
 - Include tests for new functionality and bug fixes.
 - Ensure documentation is updated for user-facing changes.
 
-## Installing the Project for Development
+## Build System: `uv`
 
-This project uses [`uv`](https://docs.astral.sh/uv/) for environment management. To set up the project for
-development, simply clone the repository, then sync the uv environment, activate it, and install the pre-commit
-environment:
+This project uses [`uv`](https://docs.astral.sh/uv/) as its sole Python package manager. **Do not
+use `pip`, `conda`, `poetry`, or `pipenv` directly.** `uv` is written in Rust by [Astral](https://astral.sh)
+(the same team that makes `ruff`).
+
+Why uv:
+
+- **Fast.** Resolves and installs dependencies in seconds, not minutes.
+- **Reproducible.** `uv.lock` pins exact versions of every transitive dependency, so collaborators
+    and CI install the identical environment.
+- **One tool, one workflow.** Replaces the `pip` + `pip-tools` + `virtualenv` + `pyenv` stack. uv
+    also manages Python interpreter versions itself — you don't need a separate `pyenv`.
+- **Modern defaults.** Lockfile-first, `pyproject.toml`-native, sensible behavior out of the box.
+
+### Install `uv`
+
+See the [official install guide](https://docs.astral.sh/uv/getting-started/installation/). The
+shortest path on Linux and macOS:
 
 ```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+On macOS you can also `brew install uv`. On Windows, see the official install guide.
+
+### Common commands
+
+```bash
+uv sync                    # install/update project deps + create .venv
+uv sync --group dev        # include the dev dependency group
+uv run <cmd>               # run a command inside the project's environment
+uv run pytest -v           # e.g. run the tests
+uv add <pkg>               # add a runtime dependency to pyproject.toml + uv.lock
+uv add --group dev <pkg>   # add a dev-only dependency
+uv lock                    # regenerate uv.lock after editing pyproject.toml by hand
+uv build                   # build a wheel + sdist into dist/
+```
+
+The project's **Python version** is pinned in `.python-version` (3.12+). uv reads this file and
+installs the matching interpreter automatically — you don't need to manage Python yourself.
+
+The project's **version number** is managed by `setuptools-scm` from git tags. Do not hardcode
+versions in `pyproject.toml`. To release a new version, tag the commit (`git tag 0.1.0 && git push --tags`)
+and the CI release workflow publishes to PyPI.
+
+## Installing the Project for Development
+
+Clone the repository, sync the environment, and install the pre-commit hooks:
+
+```bash
+git clone https://github.com/McDermottHealthAI/MHAL-template.git
+cd MHAL-template
 uv sync
-source .venv/bin/activate # Not strictly necessary, but ensures if you don't use uv things still work.
 uv run pre-commit install
 ```
 
-## Documentation Standards
+The `uv run pre-commit install` step is important — it hooks `pre-commit` into your local git so
+formatters and linters run automatically on every commit. Without it, you'll repeatedly fail CI on
+issues that would have been auto-fixed locally.
 
-Documentation should be written using
-[Google style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html).
-API validation can be tested directly inside these docstrings via doctests; this behavior is encouraged.
+## Testing
 
-Helpers like `yaml_disk` and `print_directory` can be made available by
-installing the helpers [`yaml_to_disk`](https://github.com/mmcdermott/yaml_to_disk) (which allows you to
-populate temporary directories via a yaml snippet) and
-[`pretty-print-directory`](https://github.com/mmcdermott/pretty-print-directory) (which allows you to print a
-directory structure for doctest prettification) in the development environment. Once installed, these packages
-_automatically register in the doctest namespace within pytest_, so you can use them directly in doctests
-without needing to import them.
+- **Run tests**: `uv run pytest -v`
+- **Framework**: `pytest` with `pytest-cov` for coverage, integrated with [codecov.io](https://about.codecov.io/)
+    for the coverage badge and PR-level coverage diffs.
+- **Doctests are first-class tests.** Prefer writing API-validating tests as doctests in docstrings
+    and markdown files. Use standalone `tests/**/test_*.py` files only for tests that would be
+    excessively long, complex, or unclear as doctests.
+- **TDD**: When fixing bugs or adding features, write a failing test first, confirm the failure
+    captures the intended behavior, then implement the fix.
 
-A global `conftest.py` further populates the namespace using `pytest`'s `doctest_namespace` fixture, meaning
-you rarely need explicit imports in doctests.
+### Doctests in markdown
+
+Use `>>>` and `...` prompts as you would in a docstring. **A blank line must separate the final
+output line from the closing triple-backtick.**
+
+### Doctest helpers
+
+The project root `conftest.py` pre-populates the doctest namespace via `pytest`'s
+[`doctest_namespace`](https://docs.pytest.org/en/stable/how-to/doctest.html#doctest-namespace-fixture)
+fixture so you rarely need explicit imports in doctests. Useful helpers (auto-registered if installed):
+
+- [`yaml_to_disk`](https://github.com/mmcdermott/yaml_to_disk) — create temp directory structures
+    from a YAML string.
+- [`pretty-print-directory`](https://github.com/mmcdermott/pretty-print-directory) — print
+    directory trees cleanly in doctest output (provides `print_directory` and `PrintConfig`).
+
+Both auto-register in the doctest namespace once installed.
+
+> [!NOTE]
+> The `conftest.py` lives in the project root, *not* `tests/`, so doctest fixtures and namespace
+> entries are available to doctests inside the main package code and markdown files — not just
+> the standalone test files.
+
+## Code Style
+
+- **Linter / formatter**: [`ruff`](https://docs.astral.sh/ruff/) (configured in `pyproject.toml`).
+    Line length 110.
+- **Style guide**: [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
+- **Docstrings**: [Google style](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html).
+    All public functions, classes, and modules must have docstrings. Doctests inside those
+    docstrings are encouraged and run as part of the test suite.
+- **Imports**: Sorted by `isort` rules via ruff. No unused imports (except `__init__.py` re-exports).
 
 ## Running Checks
 
-Pre-commit should run automatically upon commit (if you have installed the hooks above). You can also run it
-directly via:
+Pre-commit runs automatically on each commit once you've installed the hooks (see above). You can
+also run all hooks against the full repo at any time:
 
 ```bash
 uv run pre-commit run --all-files
 ```
 
-You can also run the tests (including doctests):
+This will **modify your code** as the hooks auto-fix many issues (formatting, import sorting,
+trailing whitespace, end-of-file newlines, markdown formatting, etc.). Run it, review the diff, and
+commit the result.
+
+Run the test suite:
 
 ```bash
 uv run pytest -v
 ```
 
-Tests and pre-commit checks are run as part of the continuous integration process, so any failures will prevent
-pull requests from being merged.
+Both pre-commit and pytest run in CI on every PR. Failures block merge.
+
+## Issue Management
+
+- **Open an issue before starting non-trivial work** so maintainers can flag duplication, scope
+    concerns, or design issues early.
+- **Search existing issues first** — even minor things may already be tracked.
+- For bug reports, include: minimal reproduction, expected vs. actual behavior, environment
+    details (Python version, uv version, OS).
+- For feature proposals, include: motivation (concrete use case), proposed API/UX sketch, and
+    whether you're volunteering to implement it.
+- Labels are managed at the [organization
+    level](https://github.com/McDermottHealthAI). Use existing labels rather than creating new
+    per-repo labels unless a repo-specific need clearly justifies it.
+
+## Pull Request Workflow
+
+- **Link PRs to issues with closing keywords.** If the PR resolves an issue, include `Closes #<n>`
+    (or `Fixes #<n>` / `Resolves #<n>`) in the PR body so GitHub auto-closes the issue on merge.
+    For PRs that relate to an issue but do not fully resolve it, use `Refs #<n>` instead so the
+    issue stays open.
+- **Watch CI after pushing.** Every time you push a commit to a PR branch, wait for the CI checks
+    to complete and assess the results. Use `gh pr checks <pr-number> --watch` to block on
+    completion. If any check fails, pull the logs (`gh run view --log-failed`), diagnose, fix, and
+    push again. Do not declare a PR ready for review while CI is red.
+- **Respond individually to every PR review comment.** Scan *both* locations: in-line review
+    comments (attached to diff lines) *and* top-level PR conversation comments. It is easy to miss
+    one set if you only look at the diff. For each comment, reply on that specific thread — not as a
+    consolidated summary comment on the PR — and either (a) describe how the comment was addressed
+    (with a commit SHA if applicable), (b) answer the question posed, or (c) push back with
+    reasoning if you disagree.
+- **Resolve AI review threads when fully addressed.** For straightforward Copilot / AI-reviewer
+    line comments where the fix is unambiguous and the reply is a simple acknowledgment, mark the
+    review thread resolved via the GraphQL API:
+    `gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"<id>"}){thread{isResolved}}}'`.
+    This only applies to review threads (line comments); top-level PR comments have no resolved
+    state. Do **not** auto-resolve threads from human reviewers — leave that to the reviewer.
+- **Sync with main via merge, not rebase.** To pick up new changes from `main` into a PR branch,
+    run `git merge origin/main` and push. Do not rebase + force-push unless the branch history is
+    obviously broken or the maintainer explicitly asks. Merge preserves review context — in-flight
+    review comments stay anchored to the lines they were written on.
+- **Scan for upstream branch updates at the start of every work stream and periodically.** Before
+    starting new work, and on long-running branches, run `git fetch --all --prune` and check
+    whether the base branch has moved: `git log --oneline HEAD..origin/<base>`. If so, merge the
+    updates in before continuing. Keeps stacked PRs coherent and surfaces conflicts early.
+- **Consider squash vs. regular merge on every PR.** Default to a regular merge; use squash only
+    when the PR is a single logical change whose per-commit history adds no value. **Never squash
+    roll-up PRs or release-candidate PRs going into `main`** — component commits are load-bearing
+    for changelogs, bisecting, and attribution.
+
+## Repository Conventions
+
+- **No data in the repo.** Datasets (public or private) belong outside the repository. Never
+    commit data files, even to private repos. Data in `git` history is recoverable after deletion;
+    if you accidentally commit data or a secret, you need to
+    [purge it from history](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository),
+    not just delete it from the current tree.
+- **No secrets in the repo.** API keys, tokens, and credentials must not appear in commits.
+    `gitleaks` runs as a pre-commit hook to catch this, but treat it as a backstop, not a substitute
+    for care.
+- **Commit messages**: Clear and focused. One logical change per commit.
+- **Branching**: Use feature branches and pull requests for all changes to `main`.
+- **Semantic versioning**: Managed through git tags (`git tag 0.1.0`); `setuptools-scm` derives the
+    package version from the latest tag.
+- **Notebooks**: Cell outputs are stripped on commit via `nbstripout`. Notebooks are linted via
+    `nbQA` + `ruff`.
+- **GitHub Actions versions** are kept current by Dependabot (configured in
+    `.github/dependabot.yml`).
 
 ## AI-Assisted Development
 
 This template is designed to work well with LLM coding agents. Agent-specific instructions live in
 `AGENTS.md` (read by Claude Code, Cursor, Copilot, Codex CLI, Aider, and others). `CLAUDE.md` is a
-symlink to `AGENTS.md` so Claude Code picks up the same instructions via its native path.
+symlink to `AGENTS.md` so Claude Code picks up the same instructions via its native path. The
+`AGENTS.md` file is intentionally short — it instructs agents to follow the conventions in *this*
+file, plus a few agent-specific notes.
 
 The rest of this section covers one-time setup for agent-assisted work on a fresh machine. It is
 optional — you can contribute without any of this — but following it lets agents be productive on

--- a/README.md
+++ b/README.md
@@ -77,29 +77,44 @@ from this repository; next, you will need to change the following aspects of the
 
 ## Documentation
 
-### Python Build System
+### Python Build System: `uv`
 
-This project is built with the [`uv`](https://docs.astral.sh/uv/) tool for managing python builds and environments. `uv` allows you to update package dependencies, install and build your package, and maintain a "lockfile" of specific package and python versions for developmental reproducibility, all through a seamless, `pip` like interface. To use `uv` to install a virtual environment with package dependencies, you can run `uv sync` when in the repository directory. Learn more about it in the documentation linked above.
+This project uses [`uv`](https://docs.astral.sh/uv/) as its sole Python package manager. `uv` is a
+fast Rust-based tool from [Astral](https://astral.sh) (the same team behind `ruff`) that replaces
+`pip`, `pip-tools`, `virtualenv`, and `pyenv` with one tool and a single, consistent workflow.
+
+Why we standardize on `uv` across the lab:
+
+- **Reproducible environments.** `uv.lock` pins exact versions of every transitive dependency, so
+    collaborators and CI install the identical environment.
+- **Fast.** Dependency resolution and installs run in seconds, not minutes.
+- **Modern defaults.** Lockfile-first, `pyproject.toml`-native; `uv` also installs the right Python
+    interpreter for you based on `.python-version`, so you don't need a separate Python-version
+    manager.
+- **One tool, one workflow** across all of our research repos, which keeps onboarding fast.
+
+The shortest path to install `uv` is `curl -LsSf https://astral.sh/uv/install.sh | sh` (Linux/macOS)
+or `brew install uv`. See the [install guide](https://docs.astral.sh/uv/getting-started/installation/)
+for other platforms, and see [`CONTRIBUTORS.md`](CONTRIBUTORS.md#build-system-uv) for the commands
+you'll use day-to-day.
 
 ### Linting / Code Style
 
-For linting and code style, we use [`ruff`](https://docs.astral.sh/ruff/) and follow the
-[Python Google Style Guide](https://google.github.io/styleguide/pyguide.html). Linting and formatting happen
-automatically upon commit via [`pre-commit`](https://pre-commit.com/) hooks. **You must install the pre-commit
-hooks locally via `uv run pre-commit install` after installing the package locally via `uv sync` to enable this
-functionality!** Regardless of pre-commit installation status, you can always run `uv run pre-commit run --all-files` to check all files at any time. _This process will modify your code_ as it will attempt to fix
-many errors automatically.
-
-Pre-commit tests are configured via the [`.pre-commit-config.yaml`](.pre-commit-config.yaml) file.
+For linting and code style we use [`ruff`](https://docs.astral.sh/ruff/) following the
+[Python Google Style Guide](https://google.github.io/styleguide/pyguide.html). Formatting and lint
+fixes happen automatically on commit via [`pre-commit`](https://pre-commit.com/) hooks, configured
+in [`.pre-commit-config.yaml`](.pre-commit-config.yaml). See
+[`CONTRIBUTORS.md`](CONTRIBUTORS.md#code-style) for install steps and the full list of hooks
+(which includes more than just ruff — secret scanning, dependency hygiene, workflow security, etc.).
 
 ### Testing
 
-We use [`pytest`](https://docs.pytest.org/en/stable/) and
-[`doctest`](https://docs.python.org/3/library/doctest.html) for testing. To run the tests, after installing the
-package locally via `uv sync`, simply run `uv run pytest` in the root directory. If you install the package via
-`pip install -e .`, you can also run `pytest` directly. In addition, we use `pytest-cov` for code coverage
-reporting, integrated with [codecov.io](https://about.codecov.io/) for tracking coverage over time, PR
-integration, and a README badge.
+We use [`pytest`](https://docs.pytest.org/en/stable/) plus
+[`doctest`](https://docs.python.org/3/library/doctest.html), with
+[`pytest-cov`](https://github.com/pytest-dev/pytest-cov) reporting coverage to
+[codecov.io](https://about.codecov.io/) for the README badge and PR-level coverage diffs. Run
+`uv run pytest -v` to execute the full suite locally; see
+[`CONTRIBUTORS.md`](CONTRIBUTORS.md#testing) for the full setup and conventions.
 
 #### Testing Style and Doctests
 
@@ -153,27 +168,29 @@ This file contains the main documentation for your project, and should be kept u
 This file contains the license for your project. Often, [The MIT License](https://opensource.org/license/mit)
 is a good choice for research projects.
 
-#### `CONTRIBUTING.md`
+#### `CONTRIBUTORS.md`
 
-This file helps guide contributors to contribute in the manner and style you prefer. It is also often used to
-guide large language model (LLM) agents that may be contributing to the project. The included guide in this
-template is a good starting point.
+This is the **source of truth** for build, test, code-style, and PR-workflow conventions. Both
+human contributors and AI agents (via `AGENTS.md`) are pointed at this file. The included guide in
+the template is a good starting point — keep it up to date as your project's conventions evolve.
 
-#### `AGENTS.md`
+#### `AGENTS.md` and `CLAUDE.md`
 
-This file provides structured instructions for AI coding agents (Claude Code, Cursor, Copilot,
-Codex, Gemini CLI, and others). It documents build commands, test conventions, code style rules,
-and repository boundaries so that agents can work effectively without repeated prompting. The
-`CLAUDE.md` symlink ensures Claude Code also reads this file via its native path. See the
-"AI-Assisted Development" section of [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for one-time setup
-instructions covering Claude Code, the `gh` CLI, and recommended MCP servers for web search and
-library documentation.
+`AGENTS.md` provides AI coding agents (Claude Code, Cursor, Copilot, Codex CLI, Gemini CLI, and
+others) with a short pointer to `CONTRIBUTORS.md` plus a handful of agent-specific reminders
+(use `gh` not the GitHub MCP, doctest namespace pre-population, TDD encouragement, what not to do).
+`CLAUDE.md` is a symlink to `AGENTS.md` so Claude Code picks up the same instructions via its
+native path. See the "AI-Assisted Development" section of [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for
+one-time setup instructions covering Claude Code, the `gh` CLI, and recommended MCP servers for
+web search and library documentation.
 
 ### Repository management
 
-This repository (by virtue of being within the [McDermott Health AI Lab GitHub
-Organization](https://github.com/McDermottHealthAI) comes pre-built with template GitHub issues. These have
-clear names and descriptions, and should be used on newly filed issues to ensure issues are easily searchable
-and clear to newcomers. Pull requests should be used for any new features to the main branch, and semantic
-versioning should be used, managed through `git` tags (e.g., `git tag 0.0.1`); these will automatically update
-the project's version due to the configuration in `pyproject.toml`.
+This repository lives within the
+[McDermott Health AI Lab GitHub Organization](https://github.com/McDermottHealthAI), which sets
+default issue labels and (in time) issue templates that propagate to new repos. Use those labels
+on new issues so filings stay searchable and consistent. All changes to `main` go through pull
+requests; see the "Pull Request Workflow" section of [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for the
+expected flow (closing keywords, CI watching, comment replies, merge-vs-rebase policy). Versioning
+follows semantic versioning, managed through `git` tags (e.g., `git tag 0.0.1`) — `setuptools-scm`
+reads the tag and stamps the package version automatically.


### PR DESCRIPTION
Closes #1, closes #2.

## What changed

### `CONTRIBUTORS.md` is now the source of truth

Reorganized to absorb the build/test/style/PR-workflow content that was previously duplicated in `AGENTS.md`. Both human contributors and AI agents (via `AGENTS.md`) are pointed at this single file. New / updated sections:

- **Build System: uv** — what it is, why we use it (reproducibility, speed, modern defaults, one tool across the lab), install instructions, day-to-day command reference. **Closes #1.**
- **Testing** — full TDD and doctest conventions, doctest helpers, conftest.py rationale.
- **Code Style** — ruff config + Google style guide pointer.
- **Issue Management** — *new section.* When to file issues, what to include in bug/feature reports, org-level label conventions. **Closes #2.**
- **Pull Request Workflow** — closing keywords, CI watching, individual comment replies, AI thread resolution, merge-not-rebase, base-branch scanning, squash policy. Moved verbatim from AGENTS.md so humans and agents read the same source.
- **Repository Conventions** — no data, no secrets (now mentions `gitleaks` backstop), commit messages, branching, semantic versioning, notebooks, Dependabot.

### `AGENTS.md` is now a thin pointer

Reduced from ~110 lines of duplication to ~30 lines covering only genuinely agent-specific things:

- \"Read CONTRIBUTORS.md first.\"
- Agent-specific tooling (use `gh` not the GitHub MCP, doctest namespace is pre-populated).
- Working style (TDD, pre-commit auto-fix awareness, doctests first-class).
- What not to do (pip, hook-skip, broad ignores, CI tampering, secrets).

`CLAUDE.md` remains a symlink to `AGENTS.md`.

### `README.md`

- **Expanded the \"Python Build System\" section** into a real \"what is uv and why we use it\" for lab members new to the tool. Brief, then points to `CONTRIBUTORS.md` for the day-to-day commands.
- **Slimmed \"Linting / Code Style\" and \"Testing\"** to remove procedural duplication. Kept the substantive doctest manifesto and Additional Testing Packages list — those are template-level rationale, not contributor instructions.
- **Fixed stale items** found in the doc-staleness sweep:
  - `#### CONTRIBUTING.md` subsection renamed to `#### CONTRIBUTORS.md` (actual filename).
  - Unclosed open paren in the Repository management paragraph (the sentence was syntactically broken) rewritten cleanly.
  - `AGENTS.md` file description rewritten to reflect its slim new role.
  - `CLAUDE.md` now described alongside `AGENTS.md` instead of being a directory-listing-only mention.

## Test plan

- [x] `uv run pre-commit run --all-files` passes
- [x] README directory-listing doctest passes
- [ ] CI green on this PR